### PR TITLE
Handle 'stream' event

### DIFF
--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -228,6 +228,16 @@ export class WebrtcConn {
         sendWebrtcConn(this, answer)
       }
     })
+    this.peer.on('stream', stream => {
+      var video = document.querySelector('video');
+
+      if ('srcObject' in video) {
+        video.srcObject = stream
+      } else {
+        video.src = window.URL.createObjectURL(stream) // for older browsers
+      }
+      video.play()
+    })    
   }
   destroy () {
     this.peer.destroy()


### PR DESCRIPTION
- Looking at simple-peer, in the README it allows for easy video/voice streaming over WebRTC. 
    - It would be good to have a capability for it to be handled within y-webrtc since it wraps over simple-peer.
    - Or the other option would be to have the Peer object being easily accessible from when you create the provider.

- The idea for usage here is you can iterate through `providers.room.webrtcConns.peers` and use `.addStream(stream)` on the other peers