### PR TITLE
Fix provider not destroying properly

### DIFF
--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -609,7 +609,7 @@ export class WebrtcProvider extends Observable {
       conn.providers.delete(this)
       if (conn.providers.size === 0) {
         conn.destroy()
-        signalingConns.delete(this.roomName)
+        signalingConns.delete(conn.url)
       }
     })
     if (this.room) {


### PR DESCRIPTION
When a signaling connection contains no providers. The connection is not deleted because it was provided with a room name instead of URL.