### PR TITLE
Update y-webrtc.js

### DIFF
--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -437,7 +437,8 @@ export class Room {
 const openRoom = (doc, provider, name, key) => {
   // there must only be one room
   if (rooms.has(name)) {
-    throw error.create(`A Yjs Doc connected to room "${name}" already exists!`)
+    rooms.get(name).destroy()
+    // throw error.create(`A Yjs Doc connected to room "${name}" already exists!`)
   }
   const room = new Room(doc, provider, name, key)
   rooms.set(name, /** @type {Room} */ (room))


### PR DESCRIPTION
If there can be only one, better to just destroy the other one. rooms is an internal var and can't be accessed anywhere  else, so it just strands a room if theres some other error.