### PR TITLE
Allow keys on service options to be optional

### DIFF
--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -540,6 +540,16 @@ export class WebrtcProvider extends Observable {
   constructor (
     roomName,
     doc,
+    /**
+     * @type {{
+     *  signaling?: string[] | null,
+     *  password?: string | null,
+     *  awareness?: awarenessProtocol.Awareness | null,
+     *  maxConns?: number | null,
+     *  filterBcConns?: boolean | null,
+     *  peerOpts?: object | null
+     * }}
+     */
     {
       signaling = ['wss://signaling.yjs.dev', 'wss://y-webrtc-signaling-eu.herokuapp.com', 'wss://y-webrtc-signaling-us.herokuapp.com'],
       password = null,


### PR DESCRIPTION
This commit addresses yjs/y-webrtc#29 by adding a TypeScript `@type`
hint for the options to the `WebRtcProvider` constructor. This hint
explicitly marks each key of the options object as optional.

For example:

```ts
     * @type {{
     *  signaling?: string[] | null,
```

identifies that `signaling` may be omitted when passing the options object.