### PR TITLE
Fix room reconnection

### DIFF
--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -358,8 +358,7 @@ export class Room {
       encoding.writeVarUint8Array(encoderAwareness, awarenessProtocol.encodeAwarenessUpdate(this.awareness, changedClients))
       broadcastRoomMessage(this, encoding.toUint8Array(encoderAwareness))
     }
-    this.doc.on('update', this._docUpdateHandler)
-    this.awareness.on('update', this._awarenessUpdateHandler)
+    
     window.addEventListener('beforeunload', () => {
       awarenessProtocol.removeAwarenessStates(this.awareness, [doc.clientID], 'window unload')
       rooms.forEach(room => {
@@ -369,6 +368,9 @@ export class Room {
   }
 
   connect () {
+    this.doc.on('update', this._docUpdateHandler)
+    this.awareness.on('update', this._awarenessUpdateHandler)
+    
     // signal through all available signaling connections
     announceSignalingInfo(this)
     const roomName = this.name


### PR DESCRIPTION
I want to make sure the following scenario is supported:

```
webrtcProvider.disconnect();
webrtcProvider.connect();
```

This way, it would be possible to simulate a user to be offline, and then reconnect. Currently, this is not supported because the updateHandler is removed, and not reconnected.

I think this PR should fix it