### PR TITLE
Fix webrtc glare

### DIFF
--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -174,6 +174,7 @@ export class WebrtcConn {
     log('establishing connection to ', logging.BOLD, remotePeerId)
     this.room = room
     this.remotePeerId = remotePeerId
+    this.glareToken = undefined
     this.closed = false
     this.connected = false
     this.synced = false
@@ -182,7 +183,11 @@ export class WebrtcConn {
      */
     this.peer = new Peer({ initiator, ...room.provider.peerOpts })
     this.peer.on('signal', signal => {
-      publishSignalingMessage(signalingConn, room, { to: remotePeerId, from: room.peerId, type: 'signal', signal })
+      if (this.glareToken === undefined) {
+        // add some randomness to the timestamp of the offer
+        this.glareToken = Date.now() + Math.random()
+      }
+      publishSignalingMessage(signalingConn, room, { to: remotePeerId, from: room.peerId, type: 'signal', token: this.glareToken, signal })
     })
     this.peer.on('connect', () => {
       log('connected to ', logging.BOLD, remotePeerId)
@@ -515,6 +520,24 @@ export class SignalingConn extends ws.WebsocketClient {
                 }
                 break
               case 'signal':
+                if (data.signal.type === 'offer') {
+                  const existingConn = webrtcConns.get(data.from)
+                  if (existingConn) {
+                    const remoteToken = data.token
+                    const localToken = existingConn.glareToken
+                    if (localToken && localToken > remoteToken) {
+                      log('offer rejected: ', data.from)
+                      return
+                    }
+                    // if we don't reject the offer, we will be accepting it and answering it
+                    existingConn.glareToken = undefined
+                  }
+                }
+                if (data.signal.type === 'answer') {
+                  log('offer answered by: ', data.from)
+                  const existingConn = webrtcConns.get(data.from)
+                  existingConn.glareToken = undefined
+                }
                 if (data.to === peerId) {
                   map.setIfUndefined(webrtcConns, data.from, () => new WebrtcConn(this, false, data.from, room)).peer.signal(data.signal)
                   emitPeerChange()


### PR DESCRIPTION
## Context

When two client simultaneously announce themselves to the signalling server, they will both create a `Peer` with `{ initiator: true }` before sending the `offer` message to each other. As such, both parties will attempt to answer each other's offer and the second answer will result in an `ERR_SET_REMOTE_DESCRIPTION`. Thereafter, the connection closes and the when the reconnection takes place, both clients have `{ initiator: false }`, causing a standstill as they wait for each other.

<img width="713" alt="Screenshot 2022-10-28 at 12 51 59 AM" src="https://user-images.githubusercontent.com/1428635/198353298-ec02bec7-6d79-49f5-b61d-ee0a20429baa.png">


<img width="1425" alt="Screenshot 2022-10-27 at 2 32 08 PM" src="https://user-images.githubusercontent.com/1428635/198351960-20f5463e-5ccf-4d3c-ab45-515f093e0ba3.png">

This issue is similar to [glare](https://www.ietf.org/proceedings/82/slides/rtcweb-10.pdf), and simple-peer is unlikely to handle this issue in the foreseeable future based on [previous discussion](https://github.com/feross/simple-peer/issues/265).

## Approach

- Generate a tiebreaker value `glareToken` for each webrtc connection object when a signal event occurs.
- Include the tiebreaker value for `signal` messages.
- When a client receives an `offer` message with a lower tiebreaker value, it is ignored.
- Tiebreaker values are cleared on both sides of the webrtc connection when a successful connection is established.