### PR TITLE
Support for obtaining the current online client

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -109,7 +109,7 @@ const onconnection = conn => {
           if (message.topic) {
             const receivers = topics.get(message.topic)
             if (receivers) {
-              message.number = receivers.size
+              message.clients = receivers.size
               receivers.forEach(receiver =>
                 send(receiver, message)
               )

--- a/bin/server.js
+++ b/bin/server.js
@@ -109,6 +109,7 @@ const onconnection = conn => {
           if (message.topic) {
             const receivers = topics.get(message.topic)
             if (receivers) {
+              message.number = receivers.size
               receivers.forEach(receiver =>
                 send(receiver, message)
               )


### PR DESCRIPTION
I had this situation: https://github.com/yjs/yjs-demos/issues/16.

To avoid the initial content being duplicated, the client needs to know if it is the first to join. Only the first to join needs to set the initial content. So I added the function.

Here is my client code:
```javascript
provider.on('synced', (val: { synced: boolean }) => {
  console.log('synced', val.synced)
  status.value = val.synced ? 'connected' : 'disconnected'
  isInitContent = true
})

let isInitContent = false
provider.signalingConns[0].on('message', (m: any) => {
  if (m?.data?.type === 'announce' && m?.number <= 1 && !isInitContent) {
    isInitContent = true
    const currentContent = editor.value?.getHTML()
    if (currentContent === '<p></p>') {
      editor.value?.commands.setContent(content, true)
    }
  }
})
```