### PR TITLE
fix(package): missing "type" property in export

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "exports": {
     "module": "./src/y-webrtc.js",
     "import": "./src/y-webrtc.js",
-    "require": "./dist/y-webrtc.cjs"
+    "require": "./dist/y-webrtc.cjs",
+    "types": "./dist/src/y-webrtc.d.ts"
   },
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
Can't get type in TypeScript `5.0.4`

![error](https://github.com/yjs/y-webrtc/assets/85140972/8b58960a-8951-4721-b7f6-04e43b83a4e0)

This PR add the missing `types` property to suppress this error.

After: 
<img width="263" alt="image" src="https://github.com/yjs/y-webrtc/assets/85140972/45cd1d2a-dea3-41c6-ae39-541bd789a2ed">


Same issues in `y-websocket`: https://github.com/yjs/y-websocket/pull/138